### PR TITLE
Fix_flaky_NotFilterOperatorTest.testNotOperator

### DIFF
--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/filter/NotFilterOperatorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/filter/NotFilterOperatorTest.java
@@ -20,6 +20,7 @@ package org.apache.pinot.core.operator.filter;
 
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Iterator;
 import java.util.Set;
 import org.apache.pinot.core.common.BlockDocIdIterator;
@@ -33,7 +34,7 @@ public class NotFilterOperatorTest {
   @Test
   public void testNotOperator() {
     int[] docIds1 = new int[]{2, 3, 10, 15, 16, 17, 18, 21, 22, 23, 24, 26, 28};
-    Set<Integer> expectedResult = new HashSet();
+    Set<Integer> expectedResult = new LinkedHashSet();
     expectedResult.addAll(Arrays.asList(0, 1, 4, 5, 6, 7, 8, 9, 11, 12, 13, 14, 19, 20, 25, 27, 29));
     Iterator<Integer> expectedIterator = expectedResult.iterator();
     NotFilterOperator notFilterOperator = new NotFilterOperator(new TestFilterOperator(docIds1), 30);


### PR DESCRIPTION
The test org.apache.pinot.core.operator.filter.NotFilterOperatorTest.testNotOperator fails because it use HashSet, an unordered and nondeterministic data structure, which can be flaky in real testing.
In this PR I replaced HashSet with LinkedHashSet.